### PR TITLE
Wode Grimoire: Prevent harvest multicast

### DIFF
--- a/Wodes_Grimoire/cards/Fast_Forward.ts
+++ b/Wodes_Grimoire/cards/Fast_Forward.ts
@@ -4,7 +4,6 @@ import type { Spell } from '../../types/cards/index';
 import { IUnit } from '../../types/entity/Unit';
 
 const {
-    PixiUtils,
     cardUtils,
     commonTypes,
     cards,
@@ -12,22 +11,13 @@ const {
 } = globalThis.SpellmasonsAPI;
 
 const { refundLastSpell } = cards;
-const { containerSpells } = PixiUtils;
 const Unit = globalThis.SpellmasonsAPI.Unit;
-const { oneOffImage, playDefaultSpellSFX } = cardUtils;
+const { playDefaultSpellSFX } = cardUtils;
 const { CardCategory, probabilityMap, CardRarity } = commonTypes;
 const Events = globalThis.SpellmasonsAPI.Events;
 
 
 const cardId = 'Fast Forward';
-//const animationPath = 'owoWIP'; //TODO
-//const imageName = 'spellmasons-mods/Wodes_grimoire/IconWIP.png'; //TODO
-/*
-This spell does NOT work well with any DOTs that deal damage at the end of the turn.
-Adding in !prediction to the function of proc'ing the events means that the player wont be able to see it
-But the player will also see the enemy take damage every tick and heal themselves before they cast
-Need to ask Jordan if onTurnEvents can have predictions passed through or to pass predictions through without prediction variable
-*/
 const spell: Spell = {
     card: {
         id: cardId,
@@ -38,9 +28,8 @@ const spell: Spell = {
         expenseScaling: 1.5,
         probability: probabilityMap[CardRarity.RARE],
         thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconFastForward.png',
-        //animationPath,
         sfx: 'push', //TODO
-        description: [`Shunt the target forward through time. Causes progression of modifiers but does not effect cooldowns.`], //TODO: better deffinition
+        description: [`Shunt the target forward through time. Causes progression of spell effects but does not affect cooldowns.`], //TODO: better deffinition
         effect: async (state, card, quantity, underworld, prediction) => {
             //Living units
             const targets = state.targetedUnits.filter(u => u.alive);

--- a/Wodes_Grimoire/cards/Harvest.ts
+++ b/Wodes_Grimoire/cards/Harvest.ts
@@ -20,26 +20,25 @@ const spell: Spell = {
     card: {
         id: cardId,
         category: CardCategory.Mana,
-        supportQuantity: true,
+        supportQuantity: false,
         manaCost: 0,
         healthCost: 35,
         expenseScaling: 1,
         probability: probabilityMap[CardRarity.UNCOMMON],
         thumbnail: 'spellmasons-mods/Wodes_grimoire/graphics/icons/spelliconHarvest.png',
         sfx: 'sacrifice',
-        description: [`Consumes target corpse for ${manaRegain} mana. Does not work on player corpses.\n\nTastes like chicken.`],
+        description: [`Consumes target corpse for ${manaRegain} mana. Does not work on player corpses. Unstackable.\n\nTastes like chicken.`],
         effect: async (state, card, quantity, underworld, prediction) => {
             let promises: any[] = [];
             let totalManaHarvested = 0;
             //Corpses only. Cleaning up another player causes a crash, all players need some unit. Can't move player corpse to OoB either cause they could be res'ed in same chain
-            const targets = state.targetedUnits.filter(u => !u.alive && u.unitType != UnitType.PLAYER_CONTROLLED);
+            //flaggedForRemoval prevents multiple casts on the same corpse
+            const targets = state.targetedUnits.filter(u => !u.alive && u.unitType != UnitType.PLAYER_CONTROLLED && u.flaggedForRemoval != true);
             for (let unit of targets) {
                 totalManaHarvested += (manaRegain * quantity);
                 const manaTrailPromises: any[] = [];
                 if (!prediction) {
-                    for (let i = 0; i < quantity; i++) {
-                        manaTrailPromises.push(Particles.makeManaTrail(unit, state.casterUnit, underworld, '#e4ffee', '#40ff66')); //Light green means souls :)
-                    }
+                    manaTrailPromises.push(Particles.makeManaTrail(unit, state.casterUnit, underworld, '#e4ffee', '#40ff66')); //Light green means souls :)
                 }
                 promises.push((prediction ? Promise.resolve() : Promise.all(manaTrailPromises)));
             }


### PR DESCRIPTION
Prevents multiple casts of harvest on the same corpse
-This does not prevent the player from adding it multiple times in a spell, just preventing the cast from going through

Updated Fast Forward description and cleaned up code